### PR TITLE
Properly wrapped Log4NetLogger using preferred method

### DIFF
--- a/src/Ninject.Extensions.Logging.Log4Net.Test/Log4netTests.cs
+++ b/src/Ninject.Extensions.Logging.Log4Net.Test/Log4netTests.cs
@@ -1,12 +1,232 @@
 namespace Ninject.Extensions.Logging.Log4Net
 {
-    using Ninject;
-    using Ninject.Extensions.Logging.Log4Net.Infrastructure;
-    using Ninject.Modules;
+    using System;
+    using System.Reflection;
+    
+	using FluentAssertions;
+
+	using log4net.Appender;
+	using log4net.Core;
+	using log4net.Repository.Hierarchy;
+
+	using Ninject;
+	using Ninject.Extensions.Logging.Classes;
+	using Ninject.Extensions.Logging.Log4Net.Infrastructure;
+	using Ninject.Modules;
+
+	using Xunit;
+
 
     public class Log4netTests : Log4netTestingContext
     {
-        // todo, add log4net specific tests
+		/// <summary>
+		/// the appender that is used to intercept the logging events
+		/// </summary>
+		private static readonly log4net.Appender.MemoryAppender testAppender;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Log4netTests"/> class.
+		/// </summary>
+		static Log4netTests()
+		{
+			// Create the appender
+			testAppender = new MemoryAppender
+			{
+				Name = "Unit Test Appender",
+				Layout = new log4net.Layout.PatternLayout("%message"),
+				Threshold = Level.Trace
+			};
+			testAppender.ActivateOptions();
+
+			// Configure the default repository
+			var root = ((Hierarchy)log4net.LogManager.GetRepository()).Root;
+			root.AddAppender(testAppender);
+			root.Repository.Configured = true;
+		}
+
+		/// <summary>
+		/// Tests info logging
+		/// </summary>
+		[Fact]
+		public void LogInfo()
+		{
+			this.TestLog(Level.Info, typeof(CtorPropertyLoggerClass).GetMethod("LogInfo"));
+		}
+
+		/// <summary>
+		/// Tests info logging with exception
+		/// </summary>
+		[Fact]
+		public void LogInfoWithException()
+		{
+			this.TestLogWithException(Level.Info, typeof(CtorPropertyLoggerClass).GetMethod("LogInfoWithException"));
+		}
+
+		/// <summary>
+		/// Tests debug logging
+		/// </summary>
+		[Fact]
+		public void LogDebug()
+		{
+			this.TestLog(Level.Debug, typeof(CtorPropertyLoggerClass).GetMethod("LogDebug"));
+		}
+
+		/// <summary>
+		/// Tests debug logging with exception
+		/// </summary>
+		[Fact]
+		public void LogDebugWithException()
+		{
+			this.TestLogWithException(Level.Debug, typeof(CtorPropertyLoggerClass).GetMethod("LogDebugWithException"));
+		}
+
+		/// <summary>
+		/// Tests warn logging
+		/// </summary>
+		[Fact]
+		public void LogWarn()
+		{
+			this.TestLog(Level.Warn, typeof(CtorPropertyLoggerClass).GetMethod("LogWarn"));
+		}
+
+		/// <summary>
+		/// Tests warn logging with exception
+		/// </summary>
+		[Fact]
+		public void LogWarnWithException()
+		{
+			this.TestLogWithException(Level.Warn, typeof(CtorPropertyLoggerClass).GetMethod("LogWarnWithException"));
+		}
+
+		/// <summary>
+		/// Tests error logging
+		/// </summary>
+		[Fact]
+		public void LogError()
+		{
+			this.TestLog(Level.Error, typeof(CtorPropertyLoggerClass).GetMethod("LogError"));
+		}
+
+		/// <summary>
+		/// Tests error logging with exception
+		/// </summary>
+		[Fact]
+		public void LogErrorWithException()
+		{
+			this.TestLogWithException(Level.Error, typeof(CtorPropertyLoggerClass).GetMethod("LogErrorWithException"));
+		}
+
+		/// <summary>
+		/// Tests fatal logging
+		/// </summary>
+		[Fact]
+		public void LogFatal()
+		{
+			this.TestLog(Level.Fatal, typeof(CtorPropertyLoggerClass).GetMethod("LogFatal"));
+		}
+
+		/// <summary>
+		/// Tests fatal logging with exception
+		/// </summary>
+		[Fact]
+		public void LogFatalWithException()
+		{
+			this.TestLogWithException(Level.Fatal, typeof(CtorPropertyLoggerClass).GetMethod("LogFatalWithException"));
+		}
+
+#if WINDOWS_PHONE
+		[Fact]
+		public void PublicLoggerPropertyIsInjected()
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<PublicPropertyLoggerClass>();
+				loggerClass.Logger.Should().NotBeNull();
+				loggerClass.Logger.Type.Should().Be(typeof(PublicPropertyLoggerClass));
+				loggerClass.Logger.GetType().Should().Be(this.LoggerType);
+			}
+		}
+
+		[Fact]
+		public void NonPublicLoggerPropertyIsNotInjected()
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<NonPublicPropertyLoggerClass>();
+				loggerClass.Logger.Should().BeNull();
+			}
+		}
+
+		[Fact]
+		public virtual void CtorLoggerPropertyIsInjected()
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<CtorPropertyLoggerClass>();
+				loggerClass.Logger.Should().NotBeNull();
+				loggerClass.Logger.Type.Should().Be(typeof(CtorPropertyLoggerClass));
+				loggerClass.Logger.GetType().Should().Be(this.LoggerType);
+			}
+		}
+
+		[Fact]
+		public void ObjectCanGetsItsOwnLogger()
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<ObjectGetsItsOwnLogger>();
+				loggerClass.Logger.Should().NotBeNull();
+				loggerClass.Logger.Type.Should().Be(typeof(ObjectGetsItsOwnLogger));
+				loggerClass.Logger.GetType().Should().Be(this.LoggerType);
+			}
+		}
+#endif
+
+		/// <summary>
+		/// Tests the logging without exception.
+		/// </summary>
+		/// <param name="level">The log level to be tested.</param>
+		/// <param name="methodInfo">The method info to be called to invoke the method to be tested.</param>
+		private void TestLog(Level level, MethodInfo methodInfo)
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<CtorPropertyLoggerClass>();
+
+				methodInfo.Invoke(loggerClass, new object[] { "message {0}", new object[] { 1 } });
+
+				var lastLogEvent = testAppender.GetEvents()[testAppender.GetEvents().Length - 1];
+				lastLogEvent.Should().NotBeNull();
+				lastLogEvent.RenderedMessage.Should().Be("message 1");
+				lastLogEvent.Level.Should().Be(level);
+				lastLogEvent.LoggerName.Should().Be(loggerClass.GetType().FullName);
+				lastLogEvent.ExceptionObject.Should().BeNull();
+			}
+		}
+
+		/// <summary>
+		/// Tests the logging with exception.
+		/// </summary>
+		/// <param name="logLevel">The log level to be tested.</param>
+		/// <param name="methodInfo">The method info to be called to invoke the method to be tested.</param>
+		private void TestLogWithException(Level level, MethodInfo methodInfo)
+		{
+			using (var kernel = this.CreateKernel())
+			{
+				var loggerClass = kernel.Get<CtorPropertyLoggerClass>();
+				var exception = new ArgumentException();
+
+				methodInfo.Invoke(loggerClass, new object[] { exception, "message {0}", new object[] { 1 } });
+
+				var lastLogEvent = testAppender.GetEvents()[testAppender.GetEvents().Length - 1];
+				lastLogEvent.Should().NotBeNull();
+				lastLogEvent.RenderedMessage.Should().Be("message 1");
+				lastLogEvent.Level.Should().Be(level);
+				lastLogEvent.LoggerName.Should().Be(loggerClass.GetType().FullName);
+				lastLogEvent.ExceptionObject.Should().BeSameAs(exception);
+			}
+
+		}
     }
 
 #if !SILVERLIGHT && !NETCF

--- a/src/Ninject.Extensions.Logging.Log4Net.Test/Ninject.Extensions.Logging.Log4Net.Test.csproj
+++ b/src/Ninject.Extensions.Logging.Log4Net.Test/Ninject.Extensions.Logging.Log4Net.Test.csproj
@@ -34,9 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
@@ -51,6 +48,12 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="FluentAssertions">
+      <HintPath>..\..\tools\FluentAssertions\Net-3.5\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit">
+      <HintPath>..\..\tools\xunit.net\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Infrastructure\Log4netTestingContext.cs" />

--- a/src/Ninject.Extensions.Logging.Log4Net/Infrastructure/Log4netLogger.cs
+++ b/src/Ninject.Extensions.Logging.Log4Net/Infrastructure/Log4netLogger.cs
@@ -49,10 +49,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <value>The name of the logger.</value>
         public override string Name
         {
-            get
-            {
-                return this.log4NetLogger.Logger.Name;
-            }
+			get { return this.log4NetLogger.Logger.Name; }
         }
 
         /// <summary>
@@ -76,10 +73,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// </summary>
         public override bool IsTraceEnabled
         {
-            get
-            {
-                return this.log4NetLogger.Logger.IsEnabledFor(Level.Trace);
-            }
+            get { return this.log4NetLogger.Logger.IsEnabledFor(Level.Trace); }
         }
 
         /// <summary>
@@ -112,7 +106,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Debug(string message)
         {
-            this.log4NetLogger.Debug(message);
+			this.Log(Level.Debug, message, null);
         }
 
         /// <summary>
@@ -122,7 +116,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Debug(string format, params object[] args)
         {
-            this.log4NetLogger.DebugFormat(format, args);
+			this.Log(Level.Debug, format, null, args);
         }
 
         /// <summary>
@@ -133,7 +127,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Debug(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Debug(args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Debug, format, exception, args);
         }
 
         /// <summary>
@@ -143,7 +137,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void DebugException(string message, Exception exception)
         {
-            this.log4NetLogger.Debug(message, exception);
+			this.Log(Level.Debug, message, exception);
         }
 
         /// <summary>
@@ -152,7 +146,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Info(string message)
         {
-            this.log4NetLogger.Info(message);
+			this.Log(Level.Info, message, null);
         }
 
         /// <summary>
@@ -162,7 +156,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Info(string format, params object[] args)
         {
-            this.log4NetLogger.InfoFormat(format, args);
+			this.Log(Level.Info, format, null, args);
         }
 
         /// <summary>
@@ -173,7 +167,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Info(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Info(args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Info, format, exception, args);
         }
 
         /// <summary>
@@ -183,7 +177,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void InfoException(string message, Exception exception)
         {
-            this.log4NetLogger.Info(message, exception);
+			this.Log(Level.Info, message, exception);
         }
 
         /// <summary>
@@ -192,7 +186,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Trace(string message)
         {
-            this.log4NetLogger.Logger.Log(Type, Level.Trace, message, null);
+			this.Log(Level.Trace, message, null);
         }
 
         /// <summary>
@@ -202,7 +196,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Trace(string format, params object[] args)
         {
-            this.log4NetLogger.Logger.Log(Type, Level.Trace, args.Length > 0 ? String.Format(format, args) : format, null);
+			this.Log(Level.Trace, format, null, args);
         }
 
         /// <summary>
@@ -213,7 +207,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Trace(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Logger.Log(Type, Level.Trace, args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Trace, format, exception, args);
         }
 
         /// <summary>
@@ -223,7 +217,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void TraceException(string message, Exception exception)
         {
-            this.log4NetLogger.Logger.Log(Type, Level.Trace, message, exception);
+			this.Log(Level.Trace, message, exception);
         }
 
         /// <summary>
@@ -232,7 +226,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Warn(string message)
         {
-            this.log4NetLogger.Warn(message);
+			this.Log(Level.Warn, message, null);
         }
 
         /// <summary>
@@ -242,7 +236,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Warn(string format, params object[] args)
         {
-            this.log4NetLogger.WarnFormat(format, args);
+			this.Log(Level.Warn, format, null, args);
         }
 
         /// <summary>
@@ -253,7 +247,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Warn(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Warn(args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Warn, format, exception, args);
         }
 
         /// <summary>
@@ -263,7 +257,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void WarnException(string message, Exception exception)
         {
-            this.log4NetLogger.Warn(message, exception);
+			this.Log(Level.Warn, message, exception);
         }
 
         /// <summary>
@@ -272,7 +266,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Error(string message)
         {
-            this.log4NetLogger.Error(message);
+			this.Log(Level.Error, message, null);
         }
 
         /// <summary>
@@ -282,7 +276,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Error(string format, params object[] args)
         {
-            this.log4NetLogger.ErrorFormat(format, args);
+			this.Log(Level.Error, format, null, args);
         }
 
         /// <summary>
@@ -293,7 +287,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Error(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Error(args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Error, format, exception, args);
         }
 
         /// <summary>
@@ -303,7 +297,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void ErrorException(string message, Exception exception)
         {
-            this.log4NetLogger.Error(message, exception);
+			this.Log(Level.Error, message, exception);
         }
 
         /// <summary>
@@ -312,7 +306,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="message">The message.</param>
         public override void Fatal(string message)
         {
-            this.log4NetLogger.Fatal(message);
+			this.Log(Level.Fatal, message, null);
         }
 
         /// <summary>
@@ -322,7 +316,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Fatal(string format, params object[] args)
         {
-            this.log4NetLogger.FatalFormat(format, args);
+			this.Log(Level.Fatal, format, null, args);
         }
 
         /// <summary>
@@ -333,7 +327,7 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="args">Any arguments required for the format template.</param>
         public override void Fatal(Exception exception, string format, params object[] args)
         {
-            this.log4NetLogger.Fatal(args.Length > 0 ? String.Format(format, args) : format, exception);
+			this.Log(Level.Fatal, format, exception, args);
         }
 
         /// <summary>
@@ -343,7 +337,26 @@ namespace Ninject.Extensions.Logging.Log4net.Infrastructure
         /// <param name="exception">The exception to log.</param>
         public override void FatalException(string message, Exception exception)
         {
-            this.log4NetLogger.Fatal(message, exception);
+			this.Log(Level.Fatal, message, exception);
         }
+
+		/// <summary>
+		/// Calls the actual log4netlogger using the preferred wrapped method.
+		/// </summary>
+		/// <param name="level">The level to log at.</param>
+		/// <param name="format">The message or format template.</param>
+		/// <param name="exception">The exception to log.</param>
+		/// <param name="args">Any arguments required for the format template.</param>
+		private void Log(Level level, string format, Exception exception, params object[] args)
+		{
+			if (this.log4NetLogger.Logger.IsEnabledFor(level)) 
+			{
+				if (args != null && args.Length > 0) {
+					this.log4NetLogger.Logger.Log(Type, level, String.Format(format, args), exception);
+				} else {
+					this.log4NetLogger.Logger.Log(Type, level, format, exception);
+				}
+			}
+		}
     }
 }


### PR DESCRIPTION
- Updated Log4NetLogger to use preferred method, so the callstack does not include wrapper.
- Formatted rest of properties to match.
- Added Unit Tests for log4net extension