### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/src/Ninject.Extensions.Logging.Log4Net.Test/Ninject.Extensions.Logging.Log4Net.Test.csproj
+++ b/src/Ninject.Extensions.Logging.Log4Net.Test/Ninject.Extensions.Logging.Log4Net.Test.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Ninject.Extensions.Logging.NLog4.Test/Ninject.Extensions.Logging.NLog4.Test.csproj
+++ b/src/Ninject.Extensions.Logging.NLog4.Test/Ninject.Extensions.Logging.NLog4.Test.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Ninject.Extensions.Logging.NLog4/Ninject.Extensions.Logging.NLog4.csproj
+++ b/src/Ninject.Extensions.Logging.NLog4/Ninject.Extensions.Logging.NLog4.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.0-beta03" />
+    <PackageReference Include="NLog" Version="4.5.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Ninject.Extensions.Logging.Serilog.Test/Ninject.Extensions.Logging.Serilog.Test.csproj
+++ b/src/Ninject.Extensions.Logging.Serilog.Test/Ninject.Extensions.Logging.Serilog.Test.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Ninject.Extensions.Logging.Serilog/Ninject.Extensions.Logging.Serilog.csproj
+++ b/src/Ninject.Extensions.Logging.Serilog/Ninject.Extensions.Logging.Serilog.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Ninject.Extensions.Logging.Tests/Ninject.Extensions.Logging.Tests.csproj
+++ b/src/Ninject.Extensions.Logging.Tests/Ninject.Extensions.Logging.Tests.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/Ninject.Extensions.Logging/Ninject.Extensions.Logging.csproj
+++ b/src/Ninject.Extensions.Logging/Ninject.Extensions.Logging.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ninject" Version="3.3.2-beta1" />
+    <PackageReference Include="Ninject" Version="3.3.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
I did try to update all dependencies to their latest stable version on the same major version.

FluentAssertions remains unchanged due to a change in it's major version which has the potential to break something. Since I do not have the time to verify if everyting is fine, I skipped it.